### PR TITLE
Enable logger when running xtask

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+env_logger = "0.9"
+log = "0.4"
 xtask-wasm = "0.1"
 yewprint-css = "0.4"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -11,6 +11,10 @@ enum Cli {
 fn main() -> Result<()> {
     let cli: Cli = clap::Parser::parse();
 
+    env_logger::builder()
+        .filter(Some("xtask"), log::LevelFilter::Info)
+        .init();
+
     match cli {
         Cli::Dist(args) => {
             let DistResult { dist_dir, .. } =


### PR DESCRIPTION
Apparently the logger was not initialized when running any xtask command. So for example the user is not informed where the dev server is running and when or why the build restarts.